### PR TITLE
Collect Only Flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,10 +39,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc65048dd435533bb1baf2ed9956b9a278fbfdcf90301b39ee117f06c0199d37"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates 3.1.2",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "atty"
@@ -63,6 +93,17 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "byteorder"
@@ -132,6 +173,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +200,15 @@ dependencies = [
  "libc",
  "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -248,6 +310,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -327,7 +398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c817c713ff9f16e06cfdc23baa3fecf1b71eaaac714816a98a560f4e350aa6"
 dependencies = [
  "hashbrown",
- "itertools",
+ "itertools 0.11.0",
  "libm",
  "ryu",
 ]
@@ -351,7 +422,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603729facf62429736ac17a9fc9fe1bf7e0eb8bde3da3b18cc2b6153150464d5"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "libm",
  "malachite-base",
 ]
@@ -362,7 +433,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c73844ccbf0e9baaf34d4a6d187f0d6a925ce8e74ef37a67d238e7d65529b38c"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "malachite-base",
  "malachite-nz",
 ]
@@ -393,6 +464,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -517,6 +594,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
 dependencies = [
  "zerocopy 0.6.6",
+]
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools 0.10.5",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -649,6 +767,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,7 +830,7 @@ checksum = "51e73421499eff08722b979d8494c3f1bc035908931a28607a9f17be6143ac11"
 dependencies = [
  "anyhow",
  "is-macro",
- "itertools",
+ "itertools 0.11.0",
  "lalrpop-util",
  "log",
  "malachite-bigint",
@@ -724,9 +871,11 @@ dependencies = [
 name = "rytest"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "clap",
  "glob",
  "notify",
+ "predicates 2.1.5",
  "pyo3",
  "rustpython-parser",
 ]
@@ -757,6 +906,26 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "serde"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "siphasher"
@@ -798,6 +967,12 @@ name = "target-lexicon"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"
@@ -920,6 +1095,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ glob = "0.3.1"
 notify = "6.1.1"
 rustpython-parser = "0.3.1"
 
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "2"
+
 [dependencies.pyo3]
 version = "0.21.2"
 features = ["auto-initialize"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 use clap::{App, Arg};
+use pyo3::exceptions::PySyntaxError;
 use rustpython_parser::{ast, Parse};
-use std::collections::HashMap;
 use std::error::Error;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::sync::mpsc::{self};
+use std::time::Instant;
 use std::{env, fs, thread};
 
 use glob::glob;
@@ -17,8 +18,8 @@ use pyo3::types::PyList;
 type Rysult<T> = Result<T, Box<dyn Error>>;
 
 pub struct Config {
+    collect_only: bool,
     files: Vec<String>,
-    watch: bool,
     file_prefix: String,
     test_prefix: String,
     verbose: bool,
@@ -26,7 +27,7 @@ pub struct Config {
 
 pub struct TestCase {
     file: String,
-    test: String,
+    name: String,
     passed: bool,
     error: Option<PyErr>,
 }
@@ -38,33 +39,33 @@ pub fn get_args() -> Rysult<Config> {
         .version("0.1.0")
         .author("Jim Kelly <pthread1981@gmail.com>")
         .about("rytest is a reasonably fast, somewhat Pytest compatible Python test runner.")
+        // An alphabetical list of arguments
         .arg(
-            Arg::with_name("files")
-                .value_name("FILE")
-                .help("Input file(s)")
-                .default_value("-")
-                .min_values(1),
-        )
-        .arg(
-            Arg::with_name("watch")
-                .short("w")
-                .long("watch")
-                .help("Watch files for changes")
+            Arg::with_name("collect_only")
+                .long("collect-only")
+                .help("only collect tests, don't run them")
                 .takes_value(false),
         )
         .arg(
             Arg::with_name("file_prefix")
                 .short("f")
-                .long("file_prefix")
+                .long("file-prefix")
                 .help("The prefix to search for to indicate a file contains tests")
                 .default_value("test_"),
         )
         .arg(
             Arg::with_name("test_prefix")
                 .short("p")
-                .long("test_prefix")
+                .long("test-prefix")
                 .help("The prefix to search for to indicate a function is a test")
                 .default_value("test_"),
+        )
+        .arg(
+            Arg::with_name("files")
+                .value_name("FILE")
+                .help("Input file(s)")
+                .default_value("-")
+                .min_values(1),
         )
         .arg(
             Arg::with_name("verbose")
@@ -76,56 +77,60 @@ pub fn get_args() -> Rysult<Config> {
         .get_matches();
 
     Ok(Config {
-        files: matches.values_of_lossy("files").unwrap(),
-        watch: matches.is_present("watch"),
+        collect_only: matches.is_present("collect_only"),
         file_prefix: matches.value_of("file_prefix").unwrap().to_string(),
         test_prefix: matches.value_of("test_prefix").unwrap().to_string(),
+        files: matches.values_of_lossy("files").unwrap(),
         verbose: matches.is_present("verbose"),
     })
 }
 
 pub fn run(config: Config) -> Rysult<()> {
+    let start = Instant::now();
+
     let (tx_files, rx_files) = mpsc::channel();
     let (tx_tests, rx_tests) = mpsc::channel();
-    let (tx_results, rx_results) = mpsc::channel();
 
     let _ = thread::spawn(move || {
         let tx_files = tx_files.clone();
-        find_files(
-            config.files.clone(),
-            config.file_prefix.as_str(),
-            config.watch,
-            tx_files,
-        )
-        .unwrap();
+        find_files(config.files.clone(), config.file_prefix.as_str(), tx_files).unwrap();
     });
 
     let _ = thread::spawn(move || {
         let tx_tests = tx_tests.clone();
-        find_tests(config.test_prefix.clone(), rx_files, tx_tests).unwrap();
+        find_tests(
+            config.test_prefix.clone(),
+            config.verbose,
+            rx_files,
+            tx_tests,
+        )
+        .unwrap();
     });
 
-    let _ = thread::spawn(move || {
-        let tx_results = tx_results.clone();
-        run_tests(rx_tests, tx_results).unwrap();
-    });
+    if !config.collect_only {
+        let (tx_results, rx_results) = mpsc::channel();
 
-    let handle_output = thread::spawn(move || {
-        let rx_results = rx_results;
-        output_results(rx_results, config.verbose).unwrap();
-    });
+        let _ = thread::spawn(move || {
+            let tx_results = tx_results.clone();
+            run_tests(rx_tests, tx_results).unwrap();
+        });
 
-    handle_output.join().unwrap();
+        let handle_output = thread::spawn(move || {
+            let rx_results = rx_results;
+            output_results(rx_results, start, config.verbose).unwrap();
+        });
+        handle_output.join().unwrap();
+    } else {
+        let handle_output = thread::spawn(move || {
+            output_collect(rx_tests, start).unwrap();
+        });
+        handle_output.join().unwrap();
+    }
 
     Ok(())
 }
 
-pub fn find_files(
-    paths: Vec<String>,
-    prefix: &str,
-    watch: bool,
-    tx: mpsc::Sender<String>,
-) -> Rysult<()> {
+pub fn find_files(paths: Vec<String>, prefix: &str, tx: mpsc::Sender<String>) -> Rysult<()> {
     for path in &paths {
         for entry in glob(path.as_str())? {
             match entry {
@@ -142,10 +147,6 @@ pub fn find_files(
         }
     }
 
-    if watch {
-        println!("Would watch files");
-    }
-
     drop(tx);
 
     Ok(())
@@ -153,6 +154,7 @@ pub fn find_files(
 
 pub fn find_tests(
     prefix: String,
+    verbose: bool,
     rx: mpsc::Receiver<String>,
     tx: mpsc::Sender<TestCase>,
 ) -> Rysult<()> {
@@ -169,71 +171,37 @@ pub fn find_tests(
                         FunctionDef(node) if node.name.starts_with(&prefix) => {
                             tx.send(TestCase {
                                 file: file_name.clone(),
-                                test: node.name.to_string(),
+                                name: node.name.to_string(),
                                 passed: false,
                                 error: None,
                             })?
                         }
-                        _ => println!("{}: Skipping {:?}\n\n", file_name, stmt),
+                        _ if verbose => println!("{}: Skipping {:?}\n\n", file_name, stmt),
+                        _ => {}
                     }
                 }
             }
-            Err(e) => println!("Error parsing {}: {}", file_name, e),
+            Err(e) => tx.send(TestCase {
+                file: file_name.clone(),
+                name: "".to_string(),
+                passed: false,
+                error: Some(PyErr::new::<PySyntaxError, _>(format!(
+                    " Error parsing {}",
+                    e
+                ))),
+            })?,
         }
     }
 
     Ok(())
 }
 
-fn get_fixtures_for_dir(dir: &Path) -> Rysult<HashMap<String, Fixture>> {
-    if !dir.is_dir() {
-        return Err("Not a directory".into());
-    }
-
-    let fixtures = HashMap::new();
-
-    let conftest = dir.join("conftest.py");
-
-    if conftest.exists() {
-        println!("Found conftest: {:?}", conftest);
-        let mut data = String::new();
-        let mut file = File::open(conftest.clone())?;
-        file.read_to_string(&mut data)?;
-        let ast = ast::Suite::parse(data.as_str(), "<embedded>");
-
-        match ast {
-            Ok(ast) => {
-                for stmt in ast {
-                    match stmt {
-                        FunctionDef(node)
-                            if node
-                                .decorator_list
-                                .iter()
-                                .any(|dec| dec.as_name_expr().unwrap().id == *"fixture") =>
-                        {
-                            println!("{:?}: Found function {:?}\n\n", dir, node)
-                        }
-                        _ => println!("{:?}: Skipping {:?}\n\n", dir, stmt),
-                    }
-                }
-            }
-            Err(e) => println!("Error parsing {:?}: {}", dir, e),
-        }
-    }
-
-    Ok(fixtures)
-}
-
 pub fn run_tests(rx: mpsc::Receiver<TestCase>, tx: mpsc::Sender<TestCase>) -> Rysult<()> {
-    // let fixtures = HashMap::new();
-
     while let Ok(mut test) = rx.recv() {
         let currrent_dir = env::current_dir().unwrap();
         let current_dir = Path::new(&currrent_dir);
         let path_buf = current_dir.join(test.file.clone());
         let path = path_buf.as_path();
-
-        let _fixtures = get_fixtures_for_dir(path.parent().unwrap())?;
 
         let py_code = fs::read_to_string(path)?;
 
@@ -248,7 +216,7 @@ pub fn run_tests(rx: mpsc::Receiver<TestCase>, tx: mpsc::Sender<TestCase>) -> Ry
             syspath.insert(0, path).unwrap();
 
             let module = PyModule::from_code_bound(py, &py_code, "", "")?;
-            let app: Py<PyAny> = module.getattr(test.test.as_str())?.into();
+            let app: Py<PyAny> = module.getattr(test.name.as_str())?.into();
             app.call0(py)
         });
 
@@ -268,7 +236,41 @@ pub fn run_tests(rx: mpsc::Receiver<TestCase>, tx: mpsc::Sender<TestCase>) -> Ry
     Ok(())
 }
 
-pub fn output_results(rx: mpsc::Receiver<TestCase>, verbose: bool) -> Rysult<()> {
+pub fn output_collect(rx: mpsc::Receiver<TestCase>, start: Instant) -> Rysult<()> {
+    let mut collected = 0;
+    let mut errors = 0;
+
+    while let Ok(test) = rx.recv() {
+        match test.error {
+            Some(_) => {
+                println!("ERROR {}", test.file);
+                errors += 1
+            }
+            None => {
+                println!("{}:{}", test.file, test.name);
+                collected += 1;
+            }
+        }
+    }
+
+    let duration = start.elapsed().as_secs_f64();
+
+    match errors {
+        0 => println!("{} tests collected in {:.2}s", collected, duration),
+        1 => println!(
+            "{} tests collected, {} error in {:.2}s",
+            collected, errors, duration
+        ),
+        _ => println!(
+            "{} tests collected, {} errors in {:.2}s",
+            collected, errors, duration
+        ),
+    }
+
+    Ok(())
+}
+
+pub fn output_results(rx: mpsc::Receiver<TestCase>, start: Instant, verbose: bool) -> Rysult<()> {
     let mut passed = 0;
     let mut failed = 0;
 
@@ -276,7 +278,7 @@ pub fn output_results(rx: mpsc::Receiver<TestCase>, verbose: bool) -> Rysult<()>
         println!(
             "{}:{} - {}",
             result.file,
-            result.test,
+            result.name,
             if result.passed { "PASSED" } else { "FAILED" }
         );
         if result.passed {
@@ -291,7 +293,9 @@ pub fn output_results(rx: mpsc::Receiver<TestCase>, verbose: bool) -> Rysult<()>
         }
     }
 
-    println!("{} passed, {} failed", passed, failed);
+    let duration = start.elapsed().as_secs_f64();
+
+    println!("{} passed, {} failed in {:2}s", passed, failed, duration);
 
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,42 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+const PRG: &str = "rytest";
+
+fn run(args: &[&str], expected_file: &str) -> TestResult {
+    println!("expected {}", &expected_file);
+    let expected = fs::read_to_string(expected_file)?;
+    Command::cargo_bin(PRG)?
+        .args(args)
+        .assert()
+        .success()
+        .stdout(expected);
+    Ok(())
+}
+
+#[test]
+fn collect_errors() -> TestResult {
+    run(
+        &["tests/**/*.py", "--collect-only"],
+        "tests/expected/collect_two_errors.out",
+    )
+}
+
+#[test]
+fn collect_error() -> TestResult {
+    run(
+        &["tests/input/bad/*.py", "--collect-only"],
+        "tests/expected/collect_one_error.out",
+    )
+}
+
+#[test]
+fn collect() -> TestResult {
+    run(
+        &["tests/input/good/*.py", "--collect-only"],
+        "tests/expected/collect.out",
+    )
+}

--- a/tests/expected/collect.out
+++ b/tests/expected/collect.out
@@ -1,0 +1,3 @@
+tests/input/good/test_success.py:test_success
+tests/input/good/test_success.py:test_more_success
+2 tests collected in 0.00s

--- a/tests/expected/collect_one_error.out
+++ b/tests/expected/collect_one_error.out
@@ -1,0 +1,4 @@
+ERROR tests/input/bad/test_other_error.py
+tests/input/bad/test_other_file.py:test_function_passes
+tests/input/bad/test_other_file.py:test_function_fails
+2 tests collected, 1 error in 0.00s

--- a/tests/expected/collect_two_errors.out
+++ b/tests/expected/collect_two_errors.out
@@ -1,0 +1,12 @@
+ERROR tests/input/bad/test_other_error.py
+tests/input/bad/test_other_file.py:test_function_passes
+tests/input/bad/test_other_file.py:test_function_fails
+tests/input/folder/test_another_file.py:test_another_function
+tests/input/folder/test_another_file.py:test_function_with_decorator
+tests/input/good/test_success.py:test_success
+tests/input/good/test_success.py:test_more_success
+ERROR tests/input/test_bad_file.py
+tests/input/test_file.py:test_function_passes
+tests/input/test_file.py:test_function_fails
+tests/input/test_fixtures.py:test_fixture
+9 tests collected, 2 errors in 0.00s

--- a/tests/input/bad/test_other_error.py
+++ b/tests/input/bad/test_other_error.py
@@ -1,0 +1,5 @@
+
+def test_function_passes():
+
+def test_function_fails():
+    assert False

--- a/tests/input/bad/test_other_file.py
+++ b/tests/input/bad/test_other_file.py
@@ -1,0 +1,7 @@
+
+
+def test_function_passes():
+    assert True
+
+def test_function_fails():
+    assert False

--- a/tests/input/good/test_success.py
+++ b/tests/input/good/test_success.py
@@ -1,0 +1,8 @@
+
+
+def test_success():
+    assert True
+
+
+def test_more_success():
+    assert True


### PR DESCRIPTION
This PR adds support for the `--collect-only` flag, which much like pytest will run through and simply do test collection.  It also adds support for timing the run as pytest does as well as adding e2e testing of the new command.

It also removes a little unused code around watch mode and fixture collection as well as renaming the `test` field on the `TestCase` struct to `name` so it reads as `test.name` rather than `test.test`.

Closes #9