### PR TITLE
Enforce Clippy on Tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         name: cargo clippy
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets --all-features -- -D warnings
       - uses: actions-rs/cargo@v1
         name: cargo test
         with:

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,4 @@
 use assert_cmd::Command;
-use predicates::prelude::*;
 use std::fs;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;


### PR DESCRIPTION
There had been a warning in #10 that hadn't been enforced by CI, this ensures it would enforce it.