### PR TITLE
Support for both attr and call style fixture marking

### DIFF
--- a/src/phases/collectors/ignore_test.rs
+++ b/src/phases/collectors/ignore_test.rs
@@ -1,0 +1,75 @@
+use rustpython_parser::ast;
+use rustpython_parser::ast::Stmt;
+use rustpython_parser::ast::Stmt::FunctionDef;
+
+pub fn is_pytest_fixture(stmt: Stmt) -> bool {
+    match stmt {
+        FunctionDef(node) => node.decorator_list.iter().any(|decorator| {
+            match decorator {
+                // handle pytest.fixture decorator called with parameters
+                ast::Expr::Call(call) => match call.func.as_attribute_expr() {
+                    Some(attr_expr) => match attr_expr.value.as_name_expr() {
+                        Some(name_expr) => {
+                            let module = name_expr.id.as_str();
+                            module == "pytest" && attr_expr.attr.as_str() == "fixture"
+                        }
+                        None => false,
+                    },
+                    None => false,
+                },
+                // handle pytest.fixture decorator called without parameters
+                ast::Expr::Attribute(attr_expr) => match attr_expr.value.as_name_expr() {
+                    Some(name_expr) => {
+                        let module = name_expr.id.as_str();
+                        module == "pytest" && attr_expr.attr.as_str() == "fixture"
+                    }
+                    None => false,
+                },
+                _ => false,
+            }
+        }),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::indoc::indoc;
+    use rustpython_parser::{ast, Parse};
+
+    #[test]
+    fn it_works_with_non_fixtures() {
+        let code = "\
+        def test_not_a_fixture():
+            pass
+        ";
+        let ast = ast::Suite::parse(code, "<embedded>");
+        let result = is_pytest_fixture(ast.unwrap().first().take().unwrap().clone());
+        assert_eq!(false, result);
+    }
+
+    #[test]
+    fn it_works_with_fixtures_with_pytest_decorator() {
+        let code = indoc! {"
+            @pytest.fixture
+            def test_fixture():
+                pass
+        "};
+        let ast = ast::Suite::parse(code, "<embedded>");
+        let result = is_pytest_fixture(ast.unwrap().first().take().unwrap().clone());
+        assert_eq!(true, result);
+    }
+
+    #[test]
+    fn it_works_with_fixtures_with_pytest_decorator_as_called() {
+        let code = indoc! {"
+            @pytest.fixture(name=\"testing\")
+            def test_fixture():
+                pass
+        "};
+        let ast = ast::Suite::parse(code, "<embedded>");
+        let result = is_pytest_fixture(ast.unwrap().first().take().unwrap().clone());
+        assert_eq!(true, result);
+    }
+}

--- a/src/phases/collectors/mod.rs
+++ b/src/phases/collectors/mod.rs
@@ -1,0 +1,1 @@
+pub mod ignore_test;

--- a/src/phases/mod.rs
+++ b/src/phases/mod.rs
@@ -1,3 +1,4 @@
 pub mod collection;
+pub mod collectors;
 pub mod execution;
 pub mod reporting;


### PR DESCRIPTION
This moves the existing logic to detect fixtures into a separate module (couldn't think of a better name than `collectors` but definitely open to suggestions here) and also adds support `pytest.fixture(name="fixture_a")` style decorators and associated tests.