### PR TITLE
Support Class-Based Test Grouping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -39,31 +39,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstyle"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
-
-[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
-
-[[package]]
-name = "assert_cmd"
-version = "2.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc65048dd435533bb1baf2ed9956b9a278fbfdcf90301b39ee117f06c0199d37"
-dependencies = [
- "anstyle",
- "bstr",
- "doc-comment",
- "predicates 3.1.2",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
 
 [[package]]
 name = "atty"
@@ -95,17 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "bstr"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +98,18 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -179,27 +159,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "filetime"
-version = "0.2.23"
+name = "encode_unicode"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "filetime"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
- "windows-sys 0.52.0",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -297,10 +277,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-macro"
-version = "0.3.5"
+name = "insta"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a85abdc13717906baccb5a1e435556ce0df215f242892f721dff62bf25288f"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+]
+
+[[package]]
+name = "insta-cmd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6"
+dependencies = [
+ "insta",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "is-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2069faacbe981460232f880d26bf3c7634e322d49053aa48c27e3ae642f728f1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -325,6 +329,12 @@ checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "kqueue"
@@ -353,16 +363,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 
 [[package]]
-name = "libc"
-version = "0.2.155"
+name = "lazy_static"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -382,9 +415,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "malachite"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6ea071913d15f7e0566bc4768aae3918906ea77f0abbb387ca7c0dc9303f90"
+checksum = "905472e3a4adfc48b7a6eeb8beb7aba09e851b9e74ba53a4b53798e401b2badf"
 dependencies = [
  "malachite-base",
  "malachite-nz",
@@ -393,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-base"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c817c713ff9f16e06cfdc23baa3fecf1b71eaaac714816a98a560f4e350aa6"
+checksum = "e5f8d7930df6fcb9c86761ca0999ba484d7b6469c81cee4a7d38da5386440f96"
 dependencies = [
  "hashbrown",
  "itertools 0.11.0",
@@ -418,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-nz"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603729facf62429736ac17a9fc9fe1bf7e0eb8bde3da3b18cc2b6153150464d5"
+checksum = "fa263ca62420c1f65cf6758f55c979a49ad83169f332e602b1890f1e1277a429"
 dependencies = [
  "itertools 0.11.0",
  "libm",
@@ -429,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "malachite-q"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73844ccbf0e9baaf34d4a6d187f0d6a925ce8e74ef37a67d238e7d65529b38c"
+checksum = "b7619384a5b9b54dd576ae5dd9a8a9438353ada4e50adf737c2e002088ba366e"
 dependencies = [
  "itertools 0.11.0",
  "malachite-base",
@@ -532,7 +565,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -589,11 +622,11 @@ checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -611,31 +644,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
-dependencies = [
- "anstyle",
- "difflib",
- "predicates-core",
-]
-
-[[package]]
 name = "predicates-core"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -750,15 +762,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
@@ -768,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -872,11 +875,12 @@ name = "rytest"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "assert_cmd",
  "clap",
  "glob",
+ "insta",
+ "insta-cmd",
  "notify",
- "predicates 2.1.5",
+ "predicates",
  "pyo3",
  "rustpython-parser",
 ]
@@ -910,23 +914,41 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "siphasher"
@@ -954,9 +976,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -965,15 +987,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "textwrap"
@@ -1098,15 +1114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,11 +1147,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1167,6 +1174,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -1294,32 +1310,12 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.6.6",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "byteorder",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,18 @@ notify = "6.1.1"
 rustpython-parser = "0.3.1"
 
 [dev-dependencies]
-assert_cmd = "2"
+insta = { version = "1.39.0", features = ["yaml"] }
+insta-cmd = "0.6.0"
 predicates = "2"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+# Makes insta faster
+[profile.dev.package]
+insta.opt-level = 3
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ rytest is a reasonably fast, somewhat Pytest compatible Python test runner.
 Note that this is under heavy development, and will not do anything for all
 but the simplest of test suites.
 
-## Running Tests
+## Usage
 
 The simple version is:
 
@@ -22,6 +22,23 @@ To test against our local test fixtures, run:
 ```bash
 cargo run -- tests/**/*.py -v
 ```
+
+### Running the Test Suite
+
+To run the test suite, run:
+
+```bash
+cargo test
+```
+
+We make use of the `insta` crate for snapshot testing. If you need to update snapshots, run:
+
+```bash
+cargo install cargo-insta
+cargo insta review
+```
+
+For more information, check out the [documentation](https://insta.rs/docs/cli/).
 
 ## Contributing
 

--- a/src/phases/collection.rs
+++ b/src/phases/collection.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use glob::glob;
 use pyo3::exceptions::PySyntaxError;
 use pyo3::PyErr;
-use rustpython_parser::ast::Stmt::FunctionDef;
+use rustpython_parser::ast::Stmt::{self, ClassDef, FunctionDef};
 use rustpython_parser::{ast, Parse};
 use std::io::Read;
 use std::{fs::File, sync::mpsc};
@@ -49,19 +49,37 @@ pub fn find_tests(
             Ok(ast) => {
                 for stmt in ast {
                     match stmt {
-                        FunctionDef(ref node) if node.name.starts_with(&prefix) => {
-                            let is_pytest_fixture: bool =
-                                ignore_test::is_pytest_fixture(stmt.clone());
-                            if !is_pytest_fixture {
-                                tx.send(TestCase {
-                                    file: file_name.clone(),
-                                    name: node.name.to_string(),
-                                    passed: false,
-                                    error: None,
-                                })?
+                        FunctionDef(ref node)
+                            if node.name.starts_with(&prefix)
+                                && !ignore_test::is_pytest_fixture(stmt.clone()) =>
+                        {
+                            tx.send(TestCase {
+                                file: file_name.clone(),
+                                name: node.name.to_string(),
+                                passed: false,
+                                error: None,
+                            })?
+                        }
+                        ClassDef(node) if node.bases.iter().any(find_unittest_base) => {
+                            let cases = find_unittest_class_cases(
+                                node.body.clone(),
+                                &prefix,
+                                file_name.clone(),
+                                verbose,
+                            );
+                            if !cases.is_empty() {
+                                for case in cases {
+                                    let class = node.name.as_str();
+                                    tx.send(TestCase {
+                                        file: file_name.clone(),
+                                        name: format!("{}::{}", class, case),
+                                        passed: false,
+                                        error: None,
+                                    })?
+                                }
                             }
                         }
-                        _ if verbose => println!("{}: Skipping {:?}\n\n", file_name, stmt),
+                        _ if verbose => println!("{}: Skipping {:#?}\n\n", file_name, stmt),
                         _ => {}
                     }
                 }
@@ -79,4 +97,211 @@ pub fn find_tests(
     }
 
     Ok(())
+}
+
+fn find_unittest_base(expr: &ast::Expr) -> bool {
+    if expr.is_attribute_expr() {
+        let attr_expr = expr.as_attribute_expr().unwrap();
+        let module = attr_expr.value.as_name_expr().unwrap().id.as_str();
+        module == "unittest" && attr_expr.attr.as_str() == "TestCase"
+    } else {
+        false
+    }
+}
+
+fn find_unittest_class_cases(
+    stmts: Vec<Stmt>,
+    prefix: &str,
+    file_name: String,
+    verbose: bool,
+) -> Vec<String> {
+    let mut cases = vec![];
+    for stmt in stmts {
+        match stmt {
+            FunctionDef(node)
+                if node.name.starts_with(prefix)
+                    && !ignore_test::is_pytest_fixture(stmt.clone()) =>
+            {
+                cases.push(node.name.to_string())
+            }
+            _ if verbose => println!("{}: Skipping {:#?}\n\n", file_name, stmt),
+            _ => {}
+        }
+    }
+    cases
+}
+
+#[cfg(test)]
+mod tests {
+    use ast::{text_size::TextRange, EmptyRange, Expr, Identifier, TextSize};
+
+    use super::*;
+
+    #[test]
+    fn test_find_unittest_base() {
+        let expr = Expr::Attribute(ast::ExprAttribute {
+            range: TextRange::new(TextSize::from(34), TextSize::from(51)),
+            value: Box::new(Expr::Name(ast::ExprName {
+                range: TextRange::new(TextSize::from(34), TextSize::from(42)),
+                id: Identifier::new("unittest".to_string()),
+                ctx: ast::ExprContext::Load,
+            })),
+            attr: Identifier::new("TestCase".to_string()),
+            ctx: ast::ExprContext::Load,
+        });
+        assert!(find_unittest_base(&expr));
+    }
+
+    #[test]
+    fn test_find_unittest_base_false() {
+        let expr = Expr::Attribute(ast::ExprAttribute {
+            range: TextRange::new(TextSize::from(34), TextSize::from(51)),
+            value: Box::new(Expr::Name(ast::ExprName {
+                range: TextRange::new(TextSize::from(34), TextSize::from(42)),
+                id: Identifier::new("unittest".to_string()),
+                ctx: ast::ExprContext::Load,
+            })),
+            attr: Identifier::new("NotTestCase".to_string()),
+            ctx: ast::ExprContext::Load,
+        });
+        assert!(!find_unittest_base(&expr));
+    }
+
+    #[test]
+    fn test_find_unittest_base_false_no_attribute_expr() {
+        let expr = Expr::Name(ast::ExprName {
+            range: TextRange::new(TextSize::from(34), TextSize::from(42)),
+            id: Identifier::new("unittest".to_string()),
+            ctx: ast::ExprContext::Load,
+        });
+        assert!(!find_unittest_base(&expr));
+    }
+
+    #[test]
+    fn test_find_unittest_class_cases() {
+        let stmts = vec![
+            FunctionDef(ast::StmtFunctionDef {
+                range: TextRange::new(TextSize::from(0), TextSize::from(0)),
+                name: Identifier::new("test_one".to_string()),
+                args: Box::new(ast::Arguments {
+                    range: EmptyRange::default(),
+                    posonlyargs: vec![],
+                    args: vec![],
+                    vararg: None,
+                    kwonlyargs: vec![],
+                    kwarg: None,
+                }),
+                body: vec![],
+                decorator_list: vec![],
+                type_params: vec![],
+                returns: None,
+                type_comment: None,
+            }),
+            FunctionDef(ast::StmtFunctionDef {
+                range: TextRange::new(TextSize::from(0), TextSize::from(0)),
+                name: Identifier::new("not_a_test".to_string()),
+                args: Box::new(ast::Arguments {
+                    range: EmptyRange::default(),
+                    posonlyargs: vec![],
+                    args: vec![],
+                    vararg: None,
+                    kwonlyargs: vec![],
+                    kwarg: None,
+                }),
+                body: vec![],
+                decorator_list: vec![],
+                type_params: vec![],
+                returns: None,
+                type_comment: None,
+            }),
+            FunctionDef(ast::StmtFunctionDef {
+                range: TextRange::new(TextSize::from(0), TextSize::from(0)),
+                name: Identifier::new("test_two".to_string()),
+                args: Box::new(ast::Arguments {
+                    range: EmptyRange::default(),
+                    posonlyargs: vec![],
+                    args: vec![],
+                    vararg: None,
+                    kwonlyargs: vec![],
+                    kwarg: None,
+                }),
+                body: vec![],
+                decorator_list: vec![],
+                type_params: vec![],
+                returns: None,
+                type_comment: None,
+            }),
+        ];
+        let prefix = "test_";
+        let file_name = "test.py".to_string();
+        let verbose = false;
+        assert_eq!(
+            find_unittest_class_cases(stmts, prefix, file_name, verbose),
+            vec!["test_one".to_string(), "test_two".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_find_unittest_class_cases_empty() {
+        let stmts = vec![
+            FunctionDef(ast::StmtFunctionDef {
+                range: TextRange::new(TextSize::from(0), TextSize::from(0)),
+                name: Identifier::new("tests_one".to_string()),
+                args: Box::new(ast::Arguments {
+                    range: EmptyRange::default(),
+                    posonlyargs: vec![],
+                    args: vec![],
+                    vararg: None,
+                    kwonlyargs: vec![],
+                    kwarg: None,
+                }),
+                body: vec![],
+                decorator_list: vec![],
+                type_params: vec![],
+                returns: None,
+                type_comment: None,
+            }),
+            FunctionDef(ast::StmtFunctionDef {
+                range: TextRange::new(TextSize::from(0), TextSize::from(0)),
+                name: Identifier::new("not_a_test".to_string()),
+                args: Box::new(ast::Arguments {
+                    range: EmptyRange::default(),
+                    posonlyargs: vec![],
+                    args: vec![],
+                    vararg: None,
+                    kwonlyargs: vec![],
+                    kwarg: None,
+                }),
+                body: vec![],
+                decorator_list: vec![],
+                type_params: vec![],
+                returns: None,
+                type_comment: None,
+            }),
+            FunctionDef(ast::StmtFunctionDef {
+                range: TextRange::new(TextSize::from(0), TextSize::from(0)),
+                name: Identifier::new("tests_two".to_string()),
+                args: Box::new(ast::Arguments {
+                    range: EmptyRange::default(),
+                    posonlyargs: vec![],
+                    args: vec![],
+                    vararg: None,
+                    kwonlyargs: vec![],
+                    kwarg: None,
+                }),
+                body: vec![],
+                decorator_list: vec![],
+                type_params: vec![],
+                returns: None,
+                type_comment: None,
+            }),
+        ];
+        let prefix = "test_";
+        let file_name = "test.py".to_string();
+        let verbose = false;
+        assert_eq!(
+            find_unittest_class_cases(stmts, prefix, file_name, verbose),
+            Vec::<String>::new()
+        );
+    }
 }

--- a/src/phases/reporting.rs
+++ b/src/phases/reporting.rs
@@ -14,7 +14,7 @@ pub fn output_collect(rx: mpsc::Receiver<TestCase>, start: Instant) -> Result<()
                 errors += 1
             }
             None => {
-                println!("{}:{}", test.file, test.name);
+                println!("{}::{}", test.file, test.name);
                 collected += 1;
             }
         }
@@ -43,7 +43,7 @@ pub fn output_results(rx: mpsc::Receiver<TestCase>, start: Instant, verbose: boo
 
     while let Ok(result) = rx.recv() {
         println!(
-            "{}:{} - {}",
+            "{}::{} - {}",
             result.file,
             result.name,
             if result.passed { "PASSED" } else { "FAILED" }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,46 +1,90 @@
-use assert_cmd::Command;
-use std::fs;
+use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
+use std::process::Command;
 
-type TestResult = Result<(), Box<dyn std::error::Error>>;
-
-const PRG: &str = "rytest";
-
-fn run(args: &[&str], expected_file: &str) -> TestResult {
-    println!("expected {}", &expected_file);
-    let expected = fs::read_to_string(expected_file)?;
-    Command::cargo_bin(PRG)?
-        .args(args)
-        .assert()
-        .success()
-        .stdout(expected);
-    Ok(())
+fn cli() -> Command {
+    Command::new(get_cargo_bin("rytest"))
 }
 
 #[test]
-fn help() -> TestResult {
-    run(&["--help"], "tests/expected/help.out")
+fn help() {
+    assert_cmd_snapshot!(cli().arg("--help"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    rytest 0.1.0
+    rytest is a reasonably fast, somewhat Pytest compatible Python test runner.
+
+    USAGE:
+        rytest [FLAGS] [OPTIONS] [FILE]...
+
+    FLAGS:
+            --collect-only    only collect tests, don't run them
+        -h, --help            Prints help information
+        -V, --version         Prints version information
+        -v, --verbose         Verbose output
+
+    OPTIONS:
+        -f, --file-prefix <file_prefix>    The prefix to search for to indicate a file contains tests [default: test_]
+        -p, --test-prefix <test_prefix>    The prefix to search for to indicate a function is a test [default: test_]
+
+    ARGS:
+        <FILE>...    Input file(s) [default: -]
+
+    ----- stderr -----
+    "###);
 }
 
 #[test]
-fn collect_errors() -> TestResult {
-    run(
-        &["tests/**/*.py", "--collect-only"],
-        "tests/expected/collect_two_errors.out",
-    )
+fn collect_errors() {
+    assert_cmd_snapshot!(cli().arg("tests/**/*.py").arg("--collect-only"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ERROR tests/input/bad/test_other_error.py
+    tests/input/bad/test_other_file.py::test_function_passes
+    tests/input/bad/test_other_file.py::test_function_fails
+    tests/input/classes/test_classes.py::SomeTest::test_something
+    tests/input/classes/test_classes.py::SomeTest::test_something_else
+    tests/input/classes/test_classes.py::SomeTest::test_assert_failure
+    tests/input/folder/test_another_file.py::test_another_function
+    tests/input/folder/test_another_file.py::test_function_with_decorator
+    tests/input/good/test_success.py::test_success
+    tests/input/good/test_success.py::test_more_success
+    ERROR tests/input/test_bad_file.py
+    tests/input/test_file.py::test_function_passes
+    tests/input/test_file.py::test_function_fails
+    tests/input/test_fixtures.py::test_fixture
+    12 tests collected, 2 errors in 0.00s
+
+    ----- stderr -----
+    "###);
 }
 
 #[test]
-fn collect_error() -> TestResult {
-    run(
-        &["tests/input/bad/*.py", "--collect-only"],
-        "tests/expected/collect_one_error.out",
-    )
+fn collect_error() {
+    assert_cmd_snapshot!(cli().arg("tests/input/bad/*.py").arg("--collect-only"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ERROR tests/input/bad/test_other_error.py
+    tests/input/bad/test_other_file.py::test_function_passes
+    tests/input/bad/test_other_file.py::test_function_fails
+    2 tests collected, 1 error in 0.00s
+
+    ----- stderr -----
+    "###);
 }
 
 #[test]
-fn collect() -> TestResult {
-    run(
-        &["tests/input/good/*.py", "--collect-only"],
-        "tests/expected/collect.out",
-    )
+fn collect() {
+    assert_cmd_snapshot!(cli().arg("tests/input/good/*.py").arg("--collect-only"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    tests/input/good/test_success.py::test_success
+    tests/input/good/test_success.py::test_more_success
+    2 tests collected in 0.00s
+
+    ----- stderr -----
+    "###);
 }

--- a/tests/input/classes/test_classes.py
+++ b/tests/input/classes/test_classes.py
@@ -1,0 +1,16 @@
+
+import unittest
+
+
+class SomeTest(unittest.TestCase):
+    def test_something(self):
+        self.assertEqual(1, 1)
+
+    def test_something_else(self):
+        assert 1 == 1
+
+    def test_assert_failure(self):
+        assert 1 == 2
+
+    def utility(self):
+        return "I return things"


### PR DESCRIPTION
This adds support for collecting tests defined in the `unittest.TestCase` style class format.  Note that this does not yet add support for executing these tests.  This will be added subsequently, and we can discuss some pros and cons of different approaches then.

Also note the following additional changes:

* Noted that pytest uses double : and we were not, fixed that.
* Moved to executing CLI tests using insta, as this allows for easy snapshots
* Moved to using `is_pytest_fixture` in the arm guard in `find_tests`'s `FunctionDef`

Closes #12