### PR TITLE
Basic support for parametrized tests - p1

### DIFF
--- a/src/phases/collectors/mod.rs
+++ b/src/phases/collectors/mod.rs
@@ -1,2 +1,3 @@
 pub mod ignore_skip;
 pub mod ignore_test;
+pub mod parametrize;

--- a/src/phases/collectors/parametrize.rs
+++ b/src/phases/collectors/parametrize.rs
@@ -1,0 +1,123 @@
+use rustpython_parser::ast;
+use rustpython_parser::ast::Stmt;
+use rustpython_parser::ast::Stmt::FunctionDef;
+
+fn generate_parameter_ids(test_name: &str, template: &str, count: usize) -> Vec<String> {
+    // Split the template into variable names
+    let variables: Vec<&str> = template.split(',').map(|s| s.trim()).collect();
+
+    let mut result = Vec::new();
+
+    // Generate combinations for each index from 0 to count-1
+    for i in 0..count {
+        let mut combination = Vec::new();
+        for var in &variables {
+            combination.push(format!("{}{}", var, i));
+        }
+        result.push(format!("{}[{}]", test_name, combination.join("-")));
+    }
+
+    result
+}
+
+pub fn expand_parameters(stmt: Stmt) -> Option<Vec<String>> {
+    let mut parameterizations = vec![];
+
+    match stmt {
+        FunctionDef(node) => {
+            for decorator in node.decorator_list {
+                if let ast::Expr::Call(call) = decorator {
+                    if let Some(attr_expr) = call.func.as_attribute_expr() {
+                        if let Some(nested_attr_expr) = attr_expr.value.as_attribute_expr() {
+                            if let Some(name_expr) = nested_attr_expr.value.as_name_expr() {
+                                let module = name_expr.id.as_str();
+                                let is_parametrized = module == "pytest"
+                                    && nested_attr_expr.attr.as_str() == "mark"
+                                    && attr_expr.attr.as_str() == "parametrize";
+
+                                if is_parametrized {
+                                    let const_expr =
+                                        call.args[0].clone().constant_expr().unwrap().clone();
+                                    let parameters = const_expr.value.as_str().unwrap();
+                                    let values = call.args[1].clone();
+                                    let parameter_call_args = values.list_expr().unwrap().elts;
+                                    parameterizations.extend(generate_parameter_ids(
+                                        node.name.as_str(),
+                                        parameters,
+                                        parameter_call_args.len(),
+                                    ))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !parameterizations.is_empty() {
+                Some(parameterizations)
+            } else {
+                Some(vec![node.name.to_string()])
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::indoc::indoc;
+    use rustpython_parser::{ast, Parse};
+
+    #[test]
+    fn it_works_with_non_parameterized_test() {
+        let code = indoc! {"
+            def test_not_parameterized():
+                pass
+        "};
+        let ast = ast::Suite::parse(code, "<embedded>");
+        let result = expand_parameters(ast.unwrap().first().take().unwrap().clone());
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), vec!["test_not_parameterized"]);
+    }
+
+    #[test]
+    fn it_works_with_single_parameterized_test() {
+        let code = indoc! {"
+            @pytest.mark.parametrize('a', [1, 2, 3])
+            def test_parameterized():
+                pass
+        "};
+        let ast = ast::Suite::parse(code, "<embedded>");
+        let result = expand_parameters(ast.unwrap().first().take().unwrap().clone());
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap(),
+            vec![
+                "test_parameterized[a0]",
+                "test_parameterized[a1]",
+                "test_parameterized[a2]"
+            ]
+        );
+    }
+
+    #[test]
+    fn it_works_with_single_parameterized_test_multiple_args() {
+        let code = indoc! {"
+            @pytest.mark.parametrize('a, b', [(1, 2), (2, 3), (3, 4)])
+            def test_parameterized():
+                pass
+        "};
+        let ast = ast::Suite::parse(code, "<embedded>");
+        let result = expand_parameters(ast.unwrap().first().take().unwrap().clone());
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap(),
+            vec![
+                "test_parameterized[a0-b0]",
+                "test_parameterized[a1-b1]",
+                "test_parameterized[a2-b2]"
+            ]
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -65,8 +65,10 @@ fn collect_errors() {
         ERROR tests/input/test_bad_file.py
         tests/input/test_file.py::test_function_passes
         tests/input/test_file.py::test_function_fails
+        tests/input/test_file.py::test_parameterized[a0-b0]
+        tests/input/test_file.py::test_parameterized[a1-b1]
         tests/input/test_fixtures.py::test_fixture
-        12 tests collected, 2 errors in <TIME>s
+        14 tests collected, 2 errors in <TIME>s
 
         ----- stderr -----
         "###)

--- a/tests/input/test_file.py
+++ b/tests/input/test_file.py
@@ -19,3 +19,8 @@ def test_function_skipped():
 @pytest.mark.skip(reason="does not work")
 def test_function_skipped_reason():
     assert utility_function() == 2
+
+
+@pytest.mark.parametrize('a,b', [(1, 2), (3, 4)])
+def test_parameterized(a, b):
+    assert a < b


### PR DESCRIPTION
This supports collection of parametrized tests. Note that this does not support multiple dimensional parametrization yet where a single test has multiple parametrization decorators.