### PR TITLE
Prints a Message Instead of Panicing for Unsupported Parameterization

### DIFF
--- a/src/phases/collectors/parametrize.rs
+++ b/src/phases/collectors/parametrize.rs
@@ -164,11 +164,6 @@ mod tests {
         let ast = ast::Suite::parse(code, "<embedded>");
         let result = expand_parameters(ast.unwrap().first().take().unwrap().clone());
         assert!(result.is_some());
-        assert_eq!(
-            result.unwrap(),
-            vec![
-                "test_parameterized",
-            ]
-        );
+        assert_eq!(result.unwrap(), vec!["test_parameterized",]);
     }
 }

--- a/src/phases/collectors/parametrize.rs
+++ b/src/phases/collectors/parametrize.rs
@@ -57,7 +57,7 @@ pub fn expand_parameters(stmt: Stmt) -> Option<Vec<String>> {
                                             ))
                                         }
 
-                                        _ => panic!("Invalid parameterization"),
+                                        _ => println!("Unsupported parameterization {:#?}", values),
                                     }
                                 }
                             }
@@ -150,6 +150,24 @@ mod tests {
                 "test_parameterized[a0-b0]",
                 "test_parameterized[a1-b1]",
                 "test_parameterized[a2-b2]"
+            ]
+        );
+    }
+
+    #[test]
+    fn it_doesnt_blow_up_on_weird_stuff() {
+        let code = indoc! {"
+            @pytest.mark.parametrize('a', [foo for foo in range(10)])
+            def test_parameterized(a):
+                pass
+        "};
+        let ast = ast::Suite::parse(code, "<embedded>");
+        let result = expand_parameters(ast.unwrap().first().take().unwrap().clone());
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap(),
+            vec![
+                "test_parameterized",
             ]
         );
     }


### PR DESCRIPTION
This should help us better unstand these cases as well as get a sense of how far we've come with the collection.