### PR TITLE
Basic Module Level Fixture Support

### DIFF
--- a/crates/rytest/src/phases/collection.rs
+++ b/crates/rytest/src/phases/collection.rs
@@ -78,6 +78,7 @@ pub fn find_tests(
                                                 name: format!("{}[{}]", node.name, param),
                                                 passed: false,
                                                 error: None,
+                                                parametrized: true,
                                             })?;
                                         }
                                     }
@@ -86,6 +87,7 @@ pub fn find_tests(
                                         name: node.name.to_string(),
                                         passed: false,
                                         error: Some(e),
+                                        parametrized: true,
                                     })?,
                                 }
                             } else {
@@ -94,6 +96,7 @@ pub fn find_tests(
                                     name: node.name.to_string(),
                                     passed: false,
                                     error: None,
+                                    parametrized: false,
                                 })?;
                             }
                         }
@@ -112,6 +115,7 @@ pub fn find_tests(
                                         name: format!("{}::{}", class, case),
                                         passed: false,
                                         error: None,
+                                        parametrized: false,
                                     })?
                                 }
                             }
@@ -129,6 +133,7 @@ pub fn find_tests(
                     " Error parsing {}",
                     e
                 ))),
+                parametrized: false,
             })?,
         }
     }

--- a/crates/rytest/src/phases/execution.rs
+++ b/crates/rytest/src/phases/execution.rs
@@ -12,7 +12,7 @@ pub fn run_tests(rx: mpsc::Receiver<TestCase>, tx: mpsc::Sender<TestCase>) -> Re
             // skip parametrized function since they are not supported yet
             test.passed = false;
             test.error = Some(PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
-                format!("Parametrized tests are not supported yet",),
+                "Parametrized tests are not supported yet".to_string(),
             ));
             tx.send(test)?;
             continue;
@@ -74,7 +74,7 @@ pub fn run_tests(rx: mpsc::Receiver<TestCase>, tx: mpsc::Sender<TestCase>) -> Re
                             match iterator.getattr(py, "__next__")?.call0(py) {
                                 Ok(next_value) => {
                                     args_vec.push(next_value);
-                                    generators.push(iterator.into());
+                                    generators.push(iterator);
                                 }
                                 Err(err) => {
                                     return Err(err);

--- a/crates/rytest/src/phases/execution.rs
+++ b/crates/rytest/src/phases/execution.rs
@@ -85,8 +85,6 @@ pub fn run_tests(rx: mpsc::Receiver<TestCase>, tx: mpsc::Sender<TestCase>) -> Re
                         // If __iter__ doesn't exist, use the value directly
                         args_vec.push(value);
                     }
-
-                    
                 } else {
                     return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
                         "No matching function found for parameter: {}",

--- a/crates/rytest/src/phases/execution.rs
+++ b/crates/rytest/src/phases/execution.rs
@@ -1,19 +1,34 @@
 use anyhow::Result;
-use pyo3::indoc::indoc;
 use pyo3::prelude::*;
-use pyo3::types::PyList;
+use pyo3::types::{PyList, PyMapping, PyString};
+use pyo3::{indoc::indoc, types::PyTuple};
 use std::{env, fs, path::Path, sync::mpsc};
 
 use crate::TestCase;
 
 pub fn run_tests(rx: mpsc::Receiver<TestCase>, tx: mpsc::Sender<TestCase>) -> Result<()> {
     while let Ok(mut test) = rx.recv() {
+        if test.parametrized {
+            // skip parametrized function since they are not supported yet
+            test.passed = false;
+            test.error = Some(PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
+                format!("Parametrized tests are not supported yet",),
+            ));
+            tx.send(test)?;
+            continue;
+        }
         let currrent_dir = env::current_dir().unwrap();
         let current_dir = Path::new(&currrent_dir);
         let path_buf = current_dir.join(test.file.clone());
         let path = path_buf.as_path();
 
-        let py_code = fs::read_to_string(path)?;
+        let mut py_code = fs::read_to_string(path)?;
+        // replace pytest fixture with noop so we can call it directly
+        let s1 = indoc! {"
+        import pytest
+        pytest.fixture = lambda func: func
+        "};
+        py_code.insert_str(0, s1);
 
         let result = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
             let syspath = py
@@ -25,10 +40,43 @@ pub fn run_tests(rx: mpsc::Receiver<TestCase>, tx: mpsc::Sender<TestCase>) -> Re
                 .unwrap();
 
             syspath.insert(0, path).unwrap();
+            syspath.insert(0, current_dir).unwrap();
 
             let module = PyModule::from_code_bound(py, &py_code, "", "")?;
             let function: Py<PyAny> = module.getattr(test.name.as_str())?.into();
-            function.call0(py)
+
+            let inspect = py.import_bound("inspect")?;
+            let signature = inspect
+                .getattr("signature")?
+                .call1((module.getattr(test.name.as_str())?,))?;
+            let binding = signature.getattr("parameters")?;
+            let parameters = binding.downcast::<PyMapping>()?;
+
+            // Prepare a vector to hold the positional arguments
+            let mut args_vec: Vec<PyObject> = Vec::new();
+
+            for item in parameters.items()?.iter()? {
+                let item = item?;
+                let param_name_obj = item.get_item(0)?; // First item is the parameter name
+                let param_name: String = param_name_obj.extract()?;
+                let param_name_py = PyString::new_bound(py, &param_name);
+                // Check if the module has a function with the same name as the parameter
+                if let Ok(func) = module.getattr(param_name_py) {
+                    // If a matching function is found, call it and store the result in args_vec
+                    let value: PyObject = func.call0()?.into();
+                    args_vec.push(value);
+                } else {
+                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                        "No matching function found for parameter: {}",
+                        param_name
+                    )));
+                }
+            }
+
+            // Create a PyTuple from the arguments vector
+            let args_tuple = PyTuple::new_bound(py, &args_vec);
+
+            function.call1(py, args_tuple)
         });
 
         test.passed = result.is_ok();

--- a/crates/rytest/src/structs.rs
+++ b/crates/rytest/src/structs.rs
@@ -16,4 +16,5 @@ pub struct TestCase {
     pub name: String,
     pub passed: bool,
     pub error: Option<PyErr>,
+    pub parametrized: bool,
 }

--- a/crates/rytest/tests/cli.rs
+++ b/crates/rytest/tests/cli.rs
@@ -7,7 +7,7 @@ fn cli() -> Command {
 
 fn setup() -> insta::Settings {
     let mut settings = insta::Settings::clone_current();
-    settings.add_filter(r"in [[:xdigit:]]+\.[[:xdigit:]]{2}s", "in <TIME>s");
+    settings.add_filter(r"in [[:xdigit:]]+\.[[:xdigit:]]{2,}s", "in <TIME>s");
 
     settings
 }
@@ -29,12 +29,9 @@ fn help() {
 
                      Options:
                            --collect-only               only collect tests, don't run them
-                       -f, --file-prefix <file_prefix>  The prefix to search for to indicate a file contains tests
-                                                        [default: test_]
-                       -p, --test-prefix <test_prefix>  The prefix to search for to indicate a function is a test
-                                                        [default: test_]
-                       -i, --ignore <ignore>            Ignore file(s) and folders. Can be used multiple times [default:
-                                                        .venv]
+                       -f, --file-prefix <file_prefix>  The prefix to search for to indicate a file contains tests [default: test_]
+                       -p, --test-prefix <test_prefix>  The prefix to search for to indicate a function is a test [default: test_]
+                       -i, --ignore <ignore>            Ignore file(s) and folders. Can be used multiple times [default: .venv]
                        -v, --verbose                    Verbose output
                        -h, --help                       Print help
                        -V, --version                    Print version
@@ -62,6 +59,7 @@ fn collect_errors() {
         tests/input/folder/test_another_file.py::test_function_with_decorator
         tests/input/good/test_success.py::test_success
         tests/input/good/test_success.py::test_more_success
+        tests/input/good/test_success.py::test_using_fixture
         ERROR tests/input/test_bad_file.py
         tests/input/test_file.py::test_function_passes
         tests/input/test_file.py::test_function_fails
@@ -82,7 +80,7 @@ fn collect_errors() {
         tests/input/test_file.py::test_parameterized_functions[int]
         tests/input/test_file.py::test_parameterized_functions[float]
         tests/input/test_fixtures.py::test_fixture
-        28 tests collected, 2 errors in <TIME>s
+        29 tests collected, 2 errors in <TIME>s
 
         ----- stderr -----
         "###)
@@ -124,6 +122,7 @@ fn collect_ignore_folder() {
         tests/input/folder/test_another_file.py::test_function_with_decorator
         tests/input/good/test_success.py::test_success
         tests/input/good/test_success.py::test_more_success
+        tests/input/good/test_success.py::test_using_fixture
         ERROR tests/input/test_bad_file.py
         tests/input/test_file.py::test_function_passes
         tests/input/test_file.py::test_function_fails
@@ -144,7 +143,7 @@ fn collect_ignore_folder() {
         tests/input/test_file.py::test_parameterized_functions[int]
         tests/input/test_file.py::test_parameterized_functions[float]
         tests/input/test_fixtures.py::test_fixture
-        26 tests collected, 1 error in <TIME>s
+        27 tests collected, 1 error in <TIME>s
 
         ----- stderr -----
         "###)
@@ -157,14 +156,34 @@ fn collect() {
 
     settings.bind(|| {
         assert_cmd_snapshot!(cli().arg("tests/input/good").arg("--collect-only"), @r###"
-                     success: true
-                     exit_code: 0
-                     ----- stdout -----
-                     tests/input/good/test_success.py::test_success
-                     tests/input/good/test_success.py::test_more_success
-                     2 tests collected in <TIME>s
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        tests/input/good/test_success.py::test_success
+        tests/input/good/test_success.py::test_more_success
+        tests/input/good/test_success.py::test_using_fixture
+        3 tests collected in <TIME>s
 
-                     ----- stderr -----
-                     "###)
+        ----- stderr -----
+        "###)
+    });
+}
+
+#[test]
+fn test() {
+    let settings = setup();
+
+    settings.bind(|| {
+        assert_cmd_snapshot!(cli().arg("tests/input/good").arg("-v"), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        tests/input/good/test_success.py::test_success - PASSED
+        tests/input/good/test_success.py::test_more_success - PASSED
+        tests/input/good/test_success.py::test_using_fixture - PASSED
+        3 passed, 0 failed in <TIME>s
+
+        ----- stderr -----
+        "###)
     });
 }

--- a/crates/rytest/tests/cli.rs
+++ b/crates/rytest/tests/cli.rs
@@ -29,9 +29,12 @@ fn help() {
 
                      Options:
                            --collect-only               only collect tests, don't run them
-                       -f, --file-prefix <file_prefix>  The prefix to search for to indicate a file contains tests [default: test_]
-                       -p, --test-prefix <test_prefix>  The prefix to search for to indicate a function is a test [default: test_]
-                       -i, --ignore <ignore>            Ignore file(s) and folders. Can be used multiple times [default: .venv]
+                       -f, --file-prefix <file_prefix>  The prefix to search for to indicate a file contains tests
+                                                        [default: test_]
+                       -p, --test-prefix <test_prefix>  The prefix to search for to indicate a function is a test
+                                                        [default: test_]
+                       -i, --ignore <ignore>            Ignore file(s) and folders. Can be used multiple times [default:
+                                                        .venv]
                        -v, --verbose                    Verbose output
                        -h, --help                       Print help
                        -V, --version                    Print version

--- a/crates/rytest/tests/input/good/test_success.py
+++ b/crates/rytest/tests/input/good/test_success.py
@@ -12,3 +12,6 @@ def test_more_success():
 @pytest.fixture
 def test_fixture():
     return "fixtures starting with test_ should be ignored during test collection"
+
+def test_using_fixture(test_fixture):
+    assert test_fixture == "fixtures starting with test_ should be ignored during test collection"

--- a/crates/rytest/tests/input/test_fixtures.py
+++ b/crates/rytest/tests/input/test_fixtures.py
@@ -4,5 +4,13 @@ import pytest
 def value():
     return 42
 
-def test_fixture(value):
+@pytest.fixture
+def yield_fixture():
+    yield 42
+    print("teardown")
+    yield 43
+    print("teardown")
+
+def test_fixture(value, yield_fixture):
     assert value == 42
+    assert yield_fixture == 42

--- a/crates/rytest/tests/input/test_fixtures.py
+++ b/crates/rytest/tests/input/test_fixtures.py
@@ -1,4 +1,8 @@
+import pytest
 
+@pytest.fixture
+def value():
+    return 42
 
 def test_fixture(value):
     assert value == 42


### PR DESCRIPTION
This PR:
- adds support for running tests with fixtures that are defined in the same file
- skips parameterized tests from the runner as they are not supported yet