### PR TITLE
Driveby: Fix master release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-14
+          - runner: macos-13
             target: x86_64
-          - runner: macos-15
+          - runner: macos-14
             target: aarch64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
-            target: x86_64
           - runner: macos-14
+            target: x86_64
+          - runner: macos-15
             target: aarch64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fix master release.

macOS 12 is deprecated as per: https://github.com/actions/runner-images/issues/10721

so we can use 13 instead which is supported on the same target. 